### PR TITLE
Add documentation about --future option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ To do so execute:
 bundle exec jekyll serve --draft
 ```
 
+In addition, if you put a date that is future for the publication, you must add --future to your order to see your post appear.
+To do so execute:
+
+```sh
+bundle exec jekyll serve --draft --future
+```
+
 ### Review a draft
 
 When someone have created a draft, we should review it before putting it live.


### PR DESCRIPTION
When you make a post and put a future publication date on it, you have to put the option --future at the server launch to see it appear.
FIX #19