### PR TITLE
Some fixes for Astro migration

### DIFF
--- a/src/content/docs/developers/Parsers/VerveineJ.md
+++ b/src/content/docs/developers/Parsers/VerveineJ.md
@@ -45,23 +45,30 @@ Usage:
 
 `VerveineJ [-h] [-i] [-format (mse|json)] [-prettyPrint] [-o <output-file-name>] [-summary] [-alllocals] [-anchor (none|default|assoc)] [-cp CLASSPATH | -autocp DIR] [-1.1 | -1 | -1.2 | -2 | ... | -1.7 | -7] <files-to-parse> | <dirs-to-parse>"`
 
-| VerveineJ options | description |
-| :---: | :--- |
-| `-h`                                      | prints this message |
-| `-i`                                      | toggles incremental parsing on (can parse a project in parts that are added to the output file) |
-| `-format (mse|json)`                      | specifies the output format (default: MSE) |
-| `-prettyPrint`                            | toggles the usage of the json pretty printer |
-| `-o <output-file-name>`                   | specifies the name of the output file (default: ouput.mse) |
-| `-summary`                                | toggles summarization of information at the level of classes. Summarizing at the level of classes does not produce Methods, Attributes, Accesses, and Invocations. Everything is represented as references between classes: e.g. \"A.m1() invokes B.m2()\" is uplifted to \"A references B\". |
-| `-alllocals`                              | Forces outputing all local variables, even those with primitive type (incompatible with \"-summary\") |
-| `-anchor (none|entity|default|assoc)` | options for source anchor information: - no entity - only named entities \[default\] - named entities+associations (_i.e._ accesses, invocations, references) |
-| `-cp CLASSPATH`                           | classpath where to look for stubs |
-| `-autocp DIR`                             | gather all jars in DIR and put them in the classpath |
-| `-filecp FILE`                            | gather all jars listed in FILE (absolute paths) and put them in the classpath |
-| `-excludepath GLOBBINGEXPR`               | A globbing expression of file path to exclude from parsing |
-| `-1.1 | -1 | -1.2 | -2 | ... | -1.7 | -7` | specifies version of Java |
-| `<files-to-parse>|<dirs-to-parse>`        | list of source files to parse or directories to search for source files |
-{: .table }
+<table>
+  <thead>
+    <tr>
+      <th>VerveineJ options</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td><code>-h</code></td><td>prints this message</td></tr>
+    <tr><td><code>-i</code></td><td>toggles incremental parsing on (can parse a project in parts that are added to the output file)</td></tr>
+    <tr><td><code>-format (mse|json)</code></td><td>specifies the output format (default: MSE)</td></tr>
+    <tr><td><code>-prettyPrint</code></td><td>toggles the usage of the json pretty printer</td></tr>
+    <tr><td><code>-o &lt;output-file-name&gt;</code></td><td>specifies the name of the output file (default: ouput.mse)</td></tr>
+    <tr><td><code>-summary</code></td><td>toggles summarization of information at the level of classes. Summarizing at the level of classes does not produce Methods, Attributes, Accesses, and Invocations. Everything is represented as references between classes: e.g. "A.m1() invokes B.m2()" is uplifted to "A references B".</td></tr>
+    <tr><td><code>-alllocals</code></td><td>Forces outputting all local variables, even those with primitive type (incompatible with "-summary")</td></tr>
+    <tr><td><code>-anchor (none|entity|default|assoc)</code></td><td>options for source anchor information: - no entity - only named entities [default] - named entities+associations (i.e. accesses, invocations, references)</td></tr>
+    <tr><td><code>-cp CLASSPATH</code></td><td>classpath where to look for stubs</td></tr>
+    <tr><td><code>-autocp DIR</code></td><td>gather all jars in DIR and put them in the classpath</td></tr>
+    <tr><td><code>-filecp FILE</code></td><td>gather all jars listed in FILE (absolute paths) and put them in the classpath</td></tr>
+    <tr><td><code>-excludepath GLOBBINGEXPR</code></td><td>A globbing expression of file path to exclude from parsing</td></tr>
+    <tr><td><code>-1.1 | -1 | -1.2 | -2 | ... | -1.7 | -7</code></td><td>specifies version of Java</td></tr>
+    <tr><td><code>&lt;files-to-parse&gt;|&lt;dirs-to-parse&gt;</code></td><td>list of source files to parse or directories to search for source files</td></tr>
+  </tbody>
+</table>
 
 ### Advanced Options
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ hero:
   image:
     file: ../../assets/architectural_map.svg
   actions:
-    - text: Getting Start
+    - text: Getting Started
       link: /beginners/install-moose/
       icon: right-arrow
     - text: Read our blogs


### PR DESCRIPTION
- Fix blatant typo in the most visible text on the landing page: `Getting Start*ed*`.
- Migrate the VerveineJ option table from Jekyll to plain HTML, which should hopefully work with any framework.